### PR TITLE
Fix warning in test

### DIFF
--- a/t/negotiate.t
+++ b/t/negotiate.t
@@ -106,7 +106,7 @@ sub show_res
 {
     print "-------------\n";
     for (@_) {
-	printf "%-6s %.3f\n", @$_;
+	printf "%-6s %.3f %6d\n", @$_;
     }
     print "-------------\n";
 }


### PR DESCRIPTION
There are three variables and printf was print two only